### PR TITLE
Fix overflow for code blocks in registry setup guide

### DIFF
--- a/components/registry-setup.tsx
+++ b/components/registry-setup.tsx
@@ -64,7 +64,7 @@ export function RegistrySetup({
           </DialogDescription>
         </DialogHeader>
         <div className="font-medium">Initialize shadcn/ui in your project</div>
-        <div className="bg-muted p-8 rounded-md">
+        <div className="bg-muted p-8 rounded-md overflow-x-auto">
           <pre className="text-sm font-mono">
             <code>npx shadcn@latest init</code>
           </pre>
@@ -82,7 +82,7 @@ export function RegistrySetup({
           >
             {isCopied ? <CheckIcon /> : <CopyIcon />}
           </Button>
-          <div className="bg-muted p-8 rounded-md">
+          <div className="bg-muted p-8 rounded-md overflow-x-auto">
             <pre className="text-sm font-mono">
               <code>{registrySetupCode}</code>
             </pre>
@@ -91,7 +91,7 @@ export function RegistrySetup({
         <div className="font-medium">
           Then use the following command to add components:
         </div>
-        <div className="bg-muted p-8 rounded-md">
+        <div className="bg-muted p-8 rounded-md overflow-x-auto">
           <pre className="text-sm font-mono">
             <code>npx shadcn@latest add @domino/[component-name]</code>
           </pre>
@@ -99,7 +99,7 @@ export function RegistrySetup({
         <div className="font-medium">
           Run the following command to setup the MCP server:
         </div>
-        <div className="bg-muted p-8 rounded-md">
+        <div className="bg-muted p-8 rounded-md overflow-x-auto">
           <pre className="text-sm font-mono">
             <code>npx shadcn@latest mcp init</code>
           </pre>

--- a/components/registry-setup.tsx
+++ b/components/registry-setup.tsx
@@ -64,7 +64,7 @@ export function RegistrySetup({
           </DialogDescription>
         </DialogHeader>
         <div className="font-medium">Initialize shadcn/ui in your project</div>
-        <div className="bg-muted p-8 rounded-md overflow-x-auto">
+        <div className="bg-muted p-8 rounded-md overflow-x-auto min-h-[120px]">
           <pre className="text-sm font-mono">
             <code>npx shadcn@latest init</code>
           </pre>
@@ -82,7 +82,7 @@ export function RegistrySetup({
           >
             {isCopied ? <CheckIcon /> : <CopyIcon />}
           </Button>
-          <div className="bg-muted p-8 rounded-md overflow-x-auto">
+          <div className="bg-muted p-8 rounded-md overflow-x-auto min-h-[120px]">
             <pre className="text-sm font-mono">
               <code>{registrySetupCode}</code>
             </pre>
@@ -91,7 +91,7 @@ export function RegistrySetup({
         <div className="font-medium">
           Then use the following command to add components:
         </div>
-        <div className="bg-muted p-8 rounded-md overflow-x-auto">
+        <div className="bg-muted p-8 rounded-md overflow-x-auto min-h-[120px]">
           <pre className="text-sm font-mono">
             <code>npx shadcn@latest add @domino/[component-name]</code>
           </pre>

--- a/components/registry-setup.tsx
+++ b/components/registry-setup.tsx
@@ -73,7 +73,7 @@ export function RegistrySetup({
           Then copy and paste the code into{" "}
           <code className="font-mono text-foreground">components.json</code>
         </div>
-        <div className="relative">
+        <div className="relative min-w-0">
           <Button
             variant="outline"
             size="icon"

--- a/components/registry-setup.tsx
+++ b/components/registry-setup.tsx
@@ -64,7 +64,7 @@ export function RegistrySetup({
           </DialogDescription>
         </DialogHeader>
         <div className="font-medium">Initialize shadcn/ui in your project</div>
-        <div className="bg-muted p-8 rounded-md overflow-x-auto min-h-[120px]">
+        <div className="bg-muted p-8 rounded-md overflow-x-auto w-full h-auto">
           <pre className="text-sm font-mono">
             <code>npx shadcn@latest init</code>
           </pre>
@@ -82,7 +82,7 @@ export function RegistrySetup({
           >
             {isCopied ? <CheckIcon /> : <CopyIcon />}
           </Button>
-          <div className="bg-muted p-8 rounded-md overflow-x-auto min-h-[120px]">
+          <div className="bg-muted p-8 rounded-md overflow-x-auto w-full h-auto">
             <pre className="text-sm font-mono">
               <code>{registrySetupCode}</code>
             </pre>
@@ -91,7 +91,7 @@ export function RegistrySetup({
         <div className="font-medium">
           Then use the following command to add components:
         </div>
-        <div className="bg-muted p-8 rounded-md overflow-x-auto min-h-[120px]">
+        <div className="bg-muted p-8 rounded-md overflow-x-auto w-full h-auto">
           <pre className="text-sm font-mono">
             <code>npx shadcn@latest add @domino/[component-name]</code>
           </pre>


### PR DESCRIPTION
## Summary
- prevent long registry setup code lines from overflowing the dialog

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch fonts from Google Fonts)*
- `npm run registry:build`


------
https://chatgpt.com/codex/tasks/task_e_68b46d89b2d0833296889ec156296276